### PR TITLE
Need -ldl for DPDK built as static library.

### DIFF
--- a/dpdk/build.go
+++ b/dpdk/build.go
@@ -18,6 +18,6 @@ package dpdk
 
 /*
 #cgo CFLAGS: -I/usr/local/include/dpdk -m64 -pthread -O3 -msse4.2
-#cgo LDFLAGS: -L/usr/local/lib -ldpdk
+#cgo LDFLAGS: -L/usr/local/lib -ldpdk -ldl
 */
 import "C"


### PR DESCRIPTION
This commit fix error in go build.
> %  go get https://github.com/lagopus/vsw.
> # github.com/lagopus/vsw/dpdk
> /usr/local/lib/librte_eal.a(eal_common_options.o): In function `eal_plugins_init':
> eal_common_options.c:(.text+0x6c9): undefined reference to `dlopen'
> eal_common_options.c:(.text+0x758): undefined reference to `dlerror'
> collect2: error: ld returned 1 exit status
